### PR TITLE
Fix title recursion for frame breaks

### DIFF
--- a/beamerthemeawesome.sty
+++ b/beamerthemeawesome.sty
@@ -84,7 +84,9 @@
 \let\oldft\frametitle
 \renewcommand\frametitle[2][]{%
 	\ifx\relax#1\relax\oldft{#2}\else%
-		\oldft{#2\hfill\normalfont\large\color{darkgray}\raisebox{0.3ex}{#1}}%
+		\ifnum\beamer@autobreakcount>0\oldft[#1]{#2}\else%
+			\oldft{#2\hfill\normalfont\large\color{darkgray}\raisebox{0.3ex}{#1}}%
+		\fi%
 	\fi%
 }
 


### PR DESCRIPTION
Hi,

what a great theme :)

However, since issues are disabled for this repo, I don't know if you are interested in any patches.
Anyway, I noticed that framebreaks are not handled correctly. 
This is due to your handling of short frame titles. 
My patch would not extend the frametitle by the short title if framebreaks are allowed.

This would fix frames like:
```latex
\begin{frame}[allowframebreaks]{This is a title for multiple frames}
	This is a really long itemize with a lot of content:
	\begin{itemize}
		\item Item 1
		      \framebreak
		\item Item 2
		      \framebreak
		\item Item 3
		      \framebreak
		\item Item 1
	\end{itemize}
\end{frame}
```